### PR TITLE
add support for vimtype Datacenter

### DIFF
--- a/checkvsphere/vcmd/datastores.py
+++ b/checkvsphere/vcmd/datastores.py
@@ -103,7 +103,7 @@ def run():
 
     datastores = []
 
-    if vimtype in [vim.HostSystem, vim.ClusterComputeResource]:
+    if vimtype in [vim.HostSystem, vim.ClusterComputeResource, vim.Datacenter]:
         try:
             vm = find_entity_views(
                 si,


### PR DESCRIPTION
We have shared VMFS datastores that are attached to multiple datacenters in our vCenter and we would like to have the option to limit the check to just the specified datacenter.

If I specify --vimtype Datacenter now, it is just silently ignored and returns the performance data for both the datastores.

Example without datacenter type support:

```
CRITICAL: usage on datastore-1677234_DC00_VM1_v8_026 is in state CRITICAL: 97.22%
usage on datastore-1677235_DC00_VM1_v8_026 is in state CRITICAL: 97.22%
| 'datastore-1677234_DC00_VM1_v8_026 usage'=97.2208036655984%;0.0:95.0;0.0:97.0;;
'datastore-1677234_DC00_VM1_v8_026 free'=1832015364096.0B;;;;
'datastore-1677234_DC00_VM1_v8_026 used'=64086874259456.0B;;;;
'datastore-1677234_DC00_VM1_v8_026 capacity'=65918889623552.0B;;;;
'datastore-1677235_DC00_VM1_v8_026 usage'=97.2208036655984%;0.0:95.0;0.0:97.0;;
'datastore-1677235_DC00_VM1_v8_026 free'=1832015364096.0B;;;;
'datastore-1677235_DC00_VM1_v8_026 used'=64086874259456.0B;;;;
'datastore-1677235_DC00_VM1_v8_026 capacity'=65918889623552.0B;;;;
'monplugin_time'=0.403427s
```

Example with datacenter type support:
```
CRITICAL: usage on datastore-1677235_DC00_VM1_v8_026 is in state CRITICAL: 97.22%
| 'datastore-1677235_DC00_VM1_v8_026 usage'=97.2208036655984%;0.0:95.0;0.0:97.0;;
'datastore-1677235_DC00_VM1_v8_026 free'=1832015364096.0B;;;;
'datastore-1677235_DC00_VM1_v8_026 used'=64086874259456.0B;;;;
'datastore-1677235_DC00_VM1_v8_026 capacity'=65918889623552.0B;;;;
'monplugin_time'=0.149224s
```

With adding the vim.Datacenter type this works now as expected.

Would be great if you could add this.

Thanks, Marc