### PR TITLE
add check to verify at least System.View permissions when using sessionfiles

### DIFF
--- a/checkvsphere/tools/service_instance.py
+++ b/checkvsphere/tools/service_instance.py
@@ -74,6 +74,8 @@ def connect(args):
     try:
         try:
             service_instance = SmartConnect(**params)
+            # Testing the sessions permissions (at least System.View is required)
+            time = service_instance.serverClock
         except Exception as e:
             if sessionId:
                 logging.debug("retry without sessionId")


### PR DESCRIPTION
Hi datamuc..

We encounter the following issue when using the --sessionfile feature.

We are using a monitoring user for accessing our esxi hosts. It can happen, that the user is created on the ESXi hosts without enough permissions and the permissions are configured some minutes/hours later. In that case, the session that will be initiated and used is valid but it has not enough permissions.

In that case, the check will fail with an unhandled exception.

``
UNKNOWN - Unhandled exception: (vim.fault.NotAuthenticated) {
   dynamicType = <unset>,
   dynamicProperty = (vmodl.DynamicProperty) [],
   msg = 'The session is not authenticated.',
   faultCause = <unset>,
   faultMessage = (vmodl.LocalizableMessage) [],
   object = 'vim.PerformanceManager:ha-perfmgr',
   privilegeId = 'System.View',
   missingPrivileges = (vim.fault.NoPermission.EntityPrivileges) []
}
``

The problem with that is, that the session will never be recreated with the new permissions and we have to manually delete the sessionfiles.

This PR just adds a call to a method of the service_instance object that requires at least System.View permissions. If these permissions are missing we get an exception and will try it again with username password.

I just added this to our environment and the session issues are gone.

Feel free to add your thoughts.. would be great to have this fixed in your release.

Regards,  Marc